### PR TITLE
make process_file process the file in one pass

### DIFF
--- a/include/bump/version.h
+++ b/include/bump/version.h
@@ -1,6 +1,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define BUMP_VERSION "0.1.0"
+#define BUMP_VERSION "0.1.1"
 
 #endif//VERSION_H

--- a/include/bump/version.h
+++ b/include/bump/version.h
@@ -1,6 +1,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define BUMP_VERSION "0.1.1"
+#define BUMP_VERSION "0.1.2"
 
 #endif//VERSION_H

--- a/src/bump/bump.c
+++ b/src/bump/bump.c
@@ -309,12 +309,11 @@ char *process_file(FileState *state) {
 
     if (keep_going) {
       fprintf(state->output, "%s\n", output_buffer);
-      return NULL;
     } else {
       fprintf(state->output, "%s", output_buffer);
       fclose(state->input);
       fclose(state->output);
-      return "End of file reached";
+      return NULL;
     }
   }
 }

--- a/src/bump/fileutil.c
+++ b/src/bump/fileutil.c
@@ -28,7 +28,7 @@ char *read_line(FILE *input, char *buffer, size_t *length, size_t limit) {
     return error;
   }
 
-  int ch;
+  int ch = EOF;
   *length = 0;
   memset(buffer, 0, limit);
 

--- a/src/main.c
+++ b/src/main.c
@@ -385,8 +385,7 @@ int main(int argc, char const *argv[]) {
   FileState state = {0};
   initialize_file_state(&state, input_file_name, output_file_name, bump_level, MAX_LINE_LENGTH);
 
-  while (!process_file(&state))
-    ;
+  process_file(&state);
 
   if (inplace) {
     int c;

--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,6 @@ static void store_bump_level_in(char *bump_level_buffer) {
     }
     if (len == 0) {
       strcpy(bump_level_buffer, "patch");
-      len = strlen("patch");
       we_have_bump = true;
     } else if (len == 1) {
       bool major = buffer[0] == 'M';
@@ -73,10 +72,14 @@ static void store_bump_level_in(char *bump_level_buffer) {
       if (minor) strcpy(bump_level_buffer, "minor");
       if (patch) strcpy(bump_level_buffer, "patch");
     } else {
-      if (strcmp(buffer, "major") == 0 || strcmp(buffer, "minor") == 0 || strcmp(buffer, "patch") == 0) {
+      convert_to_lowercase_and_store_length(buffer, buffer, &len);
+      if (len == 5 &&
+          (strcmp(buffer, "major") == 0 ||
+           strcmp(buffer, "minor") == 0 ||
+           strcmp(buffer, "patch") == 0)) {
         we_have_bump = true;
+        strcpy(bump_level_buffer, buffer);
       }
-      memcpy(bump_level_buffer, buffer, len + 1);
     }
     if (we_have_bump) {
       break;
@@ -98,22 +101,22 @@ static bool read_confirmation() {
       continue;
     }
 
-    convert_to_lowercase_and_store_length(buffer, buffer, &len);
-
     if (len == 0) {
       return true;
     } else if (len == 1) {
-      if (buffer[0] == 'y') {
+      int yn = tolower(buffer[0]);
+      if (yn == 'y') {
         return true;
       }
-      if (buffer[0] == 'n') {
+      if (yn == 'n') {
         return false;
       }
     } else {
-      if (strcmp(buffer, "yes") == 0) {
+      convert_to_lowercase_and_store_length(buffer, buffer, &len);
+      if (len == 3 && strcmp(buffer, "yes") == 0) {
         return true;
       }
-      if (strcmp(buffer, "no") == 0) {
+      if (len == 2 && strcmp(buffer, "no") == 0) {
         return false;
       }
     }


### PR DESCRIPTION
Fixes #7 

1. Makes `process_file` process the entire file per call.
2. Bumps the version number