### PR TITLE
Use strtoul

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(munit STATIC
         test/src/external/munit/munit.c
         test/include/external/munit/munit.h
         )
+set_target_properties(munit PROPERTIES CMAKE_C_STANDARD 11)
 target_include_directories(munit PUBLIC test/include/external/munit)
 
 # Configuration for the test executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ project(Introduction
         LANGUAGES C
         )
 
-# All targets must follow the C99 standard
-set(CMAKE_C_STANDARD 99)
+# All targets must follow the C11 standard
+set(CMAKE_C_STANDARD 11)
 # This property can also be set on a per-target basis.
 # However, it is recommended to apply the same standard for all targets
 # in order to ensure compatibility and simplicity.
@@ -53,7 +53,6 @@ add_library(munit STATIC
         test/src/external/munit/munit.c
         test/include/external/munit/munit.h
         )
-set_target_properties(munit PROPERTIES CMAKE_C_STANDARD 11)
 target_include_directories(munit PUBLIC test/include/external/munit)
 
 # Configuration for the test executable

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ You can download the pre-built binaries from the [Releases](https://github.com/h
 
 ## 🛠️ Building from source
 
-This project uses CMake to create cross-platform builds. As a pre-requisite, ensure that CMake and a recent C99 compiler is installed.
+This project uses CMake to create cross-platform builds. As a pre-requisite, ensure that CMake and a recent C11 compiler is installed.
+
+> ℹ️ _Technically, this project uses C99 only. C11 is for atomic integer support in munit. So if you do not plan to run the unit tests, you can probably get away with C99. If something breaks, create an issue and I will get back to you._
 
 ### Generate build files
 

--- a/test/src/run-tests.c
+++ b/test/src/run-tests.c
@@ -173,6 +173,7 @@ MunitResult process_test_cases() {
           "2.5 is a number but 1.0.7 is a version",
           "8.0. is not a version",
           "Let's put one at the end 9.",
+          "This one overflows 2.424085200077255498724.1. This one doesn't - 2.4.5",
   };
   //      ^
   //      +-- Add new input lines at the end
@@ -192,6 +193,9 @@ MunitResult process_test_cases() {
           "Let's put one at the end 9.",
           "Let's put one at the end 9.",
           "Let's put one at the end 9.",
+          "This one overflows 2.424085200077255498724.1. This one doesn't - 2.4.6",
+          "This one overflows 2.424085200077255498724.1. This one doesn't - 2.5.0",
+          "This one overflows 2.424085200077255498724.1. This one doesn't - 3.0.0",
   };
   //      ^
   //      +-- Add the three variations of the outputs at the end. Remember, the order is


### PR DESCRIPTION
Fixes #5 

Summary:
1. Reworked the `extract_decimal_number` function to handle overflow and use `strtoul`.
2. Updated `process_line` to support the overflow case.
3. Add test case to ensure that it works.